### PR TITLE
DocuPlanning: Main lifecycle Doc setup

### DIFF
--- a/docs/block-spec.md
+++ b/docs/block-spec.md
@@ -1,0 +1,211 @@
+# Crystal Circuitry — Block Specification (MVP)
+
+Namespace: `raven`  
+ID Prefix: `cc_`  
+Project: Crystal Circuitry
+
+This document defines the **minimum viable block set (MVP)** for Crystal Circuitry.
+All blocks listed here are required for the first functional release.
+
+---
+
+## Design Rules (Applies to All Blocks)
+
+- All blocks & items use the `cc_` ID prefix.
+- All state changes must be event-driven (no ticking).
+- Visual feedback must be subtle and readable.
+- Blocks should be understandable without external documentation.
+- No item movement or automation logic.
+
+---
+
+## 1. Input Blocks
+
+### 1.1 Green Crystal Switch
+**ID:** `cc_green_switch`
+
+**Role:**  
+Primary player input. Acts as a binary toggle (on/off).
+
+**States:**
+- `off`
+- `on`
+
+**Behavior:**
+- Player interaction toggles state.
+- Emits a signal event when state changes.
+- Does nothing while idle.
+
+**Textures Required:**
+- `cc_green_switch_off`
+- `cc_green_switch_on` (subtle glow)
+
+**Notes:**
+- No pulse/timer behavior in MVP.
+- This is the only direct player-operated logic block in MVP.
+
+---
+
+## 2. Signal Transfer Blocks (Targeted)
+
+### 2.1 Yellow Crystal Emitter
+**ID:** `cc_yellow_emitter`
+
+**Role:**  
+Sends a signal to exactly one paired Yellow Receiver.
+
+**States:**
+- `unlinked`
+- `linked_inactive`
+- `linked_active`
+
+**Behavior:**
+- Can be paired to one `cc_yellow_receiver`.
+- When receiving a signal, forwards it to its paired receiver.
+- Does not scan for receivers; pairing is explicit.
+
+**Textures Required:**
+- `cc_yellow_emitter_unlinked`
+- `cc_yellow_emitter_linked`
+- `cc_yellow_emitter_active`
+
+---
+
+### 2.2 Yellow Crystal Receiver
+**ID:** `cc_yellow_receiver`
+
+**Role:**  
+Receives a signal from exactly one paired Yellow Emitter.
+
+**States:**
+- `unlinked`
+- `linked_inactive`
+- `linked_active`
+
+**Behavior:**
+- Reacts only to its paired emitter.
+- Forwards signal state to any attached actuator.
+
+**Textures Required:**
+- `cc_yellow_receiver_unlinked`
+- `cc_yellow_receiver_linked`
+- `cc_yellow_receiver_active`
+
+---
+
+## 3. Signal Transfer Blocks (Broadcast / Aura)
+
+### 3.1 White Crystal Emitter
+**ID:** `cc_white_emitter`
+
+**Role:**  
+Broadcasts a signal to all White Receivers within range.
+
+**States:**
+- `inactive`
+- `active`
+
+**Behavior:**
+- Emits signal events to registered receivers within radius.
+- Radius is fixed for MVP (configurable later).
+- Broadcast occurs only on state change.
+
+**Textures Required:**
+- `cc_white_emitter_inactive`
+- `cc_white_emitter_active`
+
+**Notes:**
+- No per-tick radius scanning.
+- Receivers register/unregister themselves.
+
+---
+
+### 3.2 White Crystal Receiver
+**ID:** `cc_white_receiver`
+
+**Role:**  
+Receives broadcast signals from nearby White Emitters.
+
+**States:**
+- `inactive`
+- `active`
+
+**Behavior:**
+- Activates when any bound emitter broadcasts `on`.
+- Deactivates when all bound emitters are inactive.
+
+**Textures Required:**
+- `cc_white_receiver_inactive`
+- `cc_white_receiver_active`
+
+---
+
+## 4. Actuator Blocks
+
+### 4.1 Crystal Lamp
+**ID:** `cc_lamp`
+
+**Role:**  
+Simple visual actuator (light on/off).
+
+**States:**
+- `off`
+- `on`
+
+**Behavior:**
+- Turns on when receiving `on` signal.
+- Turns off when receiving `off` signal.
+- No light flicker or animation in MVP.
+
+**Textures Required:**
+- `cc_lamp_off`
+- `cc_lamp_on` (emissive)
+
+---
+
+### 4.2 Door Anchor Block
+**ID:** `cc_door_anchor`
+
+**Role:**  
+Relays a Crystal signal to one or two nearby door blocks, enabling synchronized opening and closing [ ≤ 5 blocks by default ].
+
+**States:**
+- `off` 
+- `on`
+
+
+**Behavior:**
+- Toggles state on signal change.
+- Only affects linked doors.
+- Allows up to 2 doors to be linked to a single anchor.
+
+**Textures Required:**
+- `cc_door_anchor_off`
+- `cc_door_anchor_on` (emissive)
+
+**Notes:**
+- MVP implementation may swap block state rather than animate movement.
+- Advanced movement systems are out of scope.
+- The Door Anchor does not store open/closed intentionally - it will store the signal it is given from a switch and relay that to the doors it's linked to.
+
+---
+
+## 5. Explicitly Out of Scope (MVP)
+
+- Timers, delays, inverters
+- Item transport or automation
+- Moving block physics
+- Multi-block machines
+- Energy generation or storage
+
+These may be added in later phases only after MVP stability.
+
+---
+
+## MVP Completion Criteria
+
+The MVP is considered complete when:
+- All listed blocks can be placed in-game.
+- Signals flow correctly between switches, transmitters, and actuators.
+- State persists across server restarts.
+- No noticeable performance degradation occurs with dozens of blocks active.

--- a/docs/dev-plan.md
+++ b/docs/dev-plan.md
@@ -1,0 +1,119 @@
+# Crystal Circuitry — Development Plan
+
+Plugin Namespace: `raven`  
+Asset/ID Prefix: `cc_`  
+Project Name: Crystal Circuitry
+
+## Guiding Constraints
+- Not a factory/automation mod (no belts, hoppers, item logistics).
+- Focus: redstone-adjacent building functionality (doors, hidden doors, moving walls, lights, puzzles).
+- Performance-first: event-driven updates; avoid per-tick scanning.
+- Visual clarity: subtle VFX; avoid constant beams/particle spam.
+
+---
+
+## Phase 1 — Project Setup ✅
+### Goals
+- Stable dev environment and repeatable run loop.
+- Plugin loads under correct identity.
+
+### Checklist
+- [x] Repo created (fork) and cloned locally
+- [x] Gradle builds successfully
+- [x] Dev server runs from IntelliJ Run Configuration
+- [x] Plugin identity claimed: `raven:CrystalCircuitry`
+- [x] Server log confirms plugin is listed/loaded
+- [x] Changes committed and pushed to GitHub (rename/claim work)
+
+### Exit Criteria
+- You can run server and see `raven:CrystalCircuitry` in logs every time.
+
+---
+
+## Phase 2 — Design & Documentation (CURRENT)
+### Goals
+- Create a “single source of truth” spec for blocks/items/states/textures/behavior.
+- Lock MVP scope and naming conventions before implementation.
+
+### Documents
+- [x] `docs/dev-plan.md` (this file)
+- [ ] `docs/block-spec.md` (core MVP block/item definitions)
+- [ ] `docs/test-plan.md` (repeatable tests + perf checks)
+
+### Checklist
+- [ ] Decide MVP block set
+- [ ] Define IDs for each block/item using `cc_` prefix
+- [ ] Define block states per block (on/off, linked/unlinked, etc.)
+- [ ] Define texture list per block (by state)
+- [ ] Define interaction rules (inputs → signals → actuators)
+- [ ] Define what is explicitly out-of-scope for MVP
+
+### Exit Criteria
+- A teammate could create assets from `block-spec.md` without asking questions.
+- MVP scope is clear enough to implement without redesign.
+
+---
+
+## Phase 3 — Implementation: Assets
+### Goals
+- Create all MVP blocks/items in the Asset Editor (or pack format).
+- Ensure visuals are readable and consistent.
+
+### Checklist
+- [ ] Create texture set for each MVP block (including on/off variants)
+- [ ] Define block models (start with simple cubes where possible)
+- [ ] Define block state variants (on/off, linked, active)
+- [ ] Define crafting recipes (shards → components)
+- [ ] Spawn/creative access for testing
+
+### Exit Criteria
+- All MVP blocks can be placed in-game and display correct states.
+
+---
+
+## Phase 4 — Implementation: Plugin Logic
+### Goals
+- Implement signal + actuator logic with event-driven updates.
+- Persist links/bindings.
+
+### Checklist
+- [ ] Green switch toggles emit signal events
+- [ ] Yellow linking: 1-to-1 emitter/receiver pairing
+- [ ] White aura: broadcast within radius via receiver registration (no scanning)
+- [ ] Actuators: lamp + hidden door respond to signals
+- [ ] Save/load: links persist across server restart
+- [ ] Performance guardrails: no global ticking loops
+
+### Exit Criteria
+- MVP demo works in a fresh world, after a restart, without lag spikes.
+
+---
+
+## Phase 5 — Polish & Submission Prep
+### Goals
+- Improve usability, feedback, and stability.
+
+### Checklist
+- [ ] Add subtle VFX/SFX feedback (toggle pulse, active glow)
+- [ ] Add in-game linking UX (simple prompts/indicators)
+- [ ] Add documentation: how to use each block
+- [ ] Build release artifact (jar/pack)
+- [ ] Verify clean install on a second machine or fresh folder
+
+### Exit Criteria
+- A new user can install and use the mod from README + in-game cues.
+
+---
+
+## MVP Scope (initial target)
+In scope:
+- cc_green_switch (toggle input)
+- cc_yellow_emitter / cc_yellow_receiver (1-to-1 link)
+- cc_white_emitter / cc_white_receiver (broadcast aura)
+- cc_lamp (on/off)
+- cc_hidden_door (open/close or solid/passable)
+
+Out of scope (MVP):
+- Item automation, inventory movers, belts, hoppers
+- Complex movers/physics systems
+- Advanced logic gates beyond basic toggle (timers/inverters later)

--- a/docs/implementation-order.md
+++ b/docs/implementation-order.md
@@ -1,0 +1,382 @@
+# Crystal Circuitry — Implementation Order & Architecture Checklist (MVP)
+
+Namespace: `raven`  
+ID Prefix: `cc_`  
+Project: Crystal Circuitry  
+Applies To: MVP only
+
+This document defines **what to implement, in what order, and why**, to deliver the Crystal Circuitry MVP with minimal refactoring, strong test coverage, and stable performance.
+
+Guiding rule: **Build core logic first, prove it with tests, then integrate with the game — but ensure assets exist early so you can validate in-world quickly.**
+
+---
+
+## Guiding Architecture Principles
+
+- Event-driven only (no ticking, no polling)
+- Core logic must be testable without a running server
+- World-facing code should be thin adapters around core systems
+- State must be explicit and serializable
+- UI drives behavior; UI must not contain business logic
+- Asset work should be incremental and testable: start with placeholders, then iterate
+
+---
+
+## Architecture Layers
+
+Implementation is divided into five layers:
+
+0. Asset Pack Layer (blocks/items/models/textures/blockstates)
+1. Core Logic Layer (pure Java, unit-tested)
+2. Persistence Layer (save/load safety)
+3. World Integration Layer (blocks, UI, events)
+4. Polish & Lockdown Layer (cleanup, submission readiness)
+
+Do not mix responsibilities across layers.
+
+---
+
+## Phase 0 — Asset Pack Foundation (Required Before Gameplay Integration)
+
+**Goal:** Ensure every MVP block exists in-game with basic visuals and the required block states, even if logic is not yet wired.
+
+### 0.1 Define Asset IDs and Folder Structure
+
+Create asset IDs (MVP):
+
+- `cc_green_switch`
+- `cc_yellow_emitter`
+- `cc_yellow_receiver`
+- `cc_white_emitter`
+- `cc_white_receiver`
+- `cc_lamp`
+- `cc_door_anchor`
+
+Confirm your pack namespace remains consistent with plugin identity (`raven`).
+
+---
+
+### 0.2 Placeholder Textures and Models
+
+Create minimal textures for each block, even if they are simple placeholders:
+
+- `cc_green_switch_off`, `cc_green_switch_on`
+- `cc_yellow_emitter_unlinked`, `cc_yellow_emitter_linked`, `cc_yellow_emitter_active`
+- `cc_yellow_receiver_unlinked`, `cc_yellow_receiver_linked`, `cc_yellow_receiver_active`
+- `cc_white_emitter_inactive`, `cc_white_emitter_active`
+- `cc_white_receiver_inactive`, `cc_white_receiver_active`
+- `cc_lamp_off`, `cc_lamp_on`
+- `cc_door_anchor_off`, `cc_door_anchor_on`
+
+Models:
+- MVP default: simple cube models for all blocks unless a special shape is needed.
+- Any non-cube model is optional and can be added during polish.
+
+---
+
+### 0.3 Block Definitions
+
+Create block definitions for each MVP block:
+- can be placed in-world
+- appears in creative inventory (or your dev access mechanism)
+- has correct default state
+
+---
+
+### 0.4 Block State Variants (Critical)
+
+Define block state toggles required by `block-spec.md`:
+
+- `cc_green_switch`: `off/on`
+- `cc_yellow_emitter`: `unlinked/linked_inactive/linked_active`
+- `cc_yellow_receiver`: `unlinked/linked_inactive/linked_active`
+- `cc_white_emitter`: `inactive/active`
+- `cc_white_receiver`: `inactive/active`
+- `cc_lamp`: `off/on`
+- `cc_door_anchor`: `off/on`
+
+Asset-layer expectation:
+- The block state can visually change (texture/model swap) when state changes.
+- Do not implement signal logic here; just ensure the state variants exist and render.
+
+---
+
+### 0.5 Asset Smoke Test (In-World)
+
+Before writing any logic:
+- Place each block in-world.
+- Verify textures/models display.
+- Verify each block has a valid default state.
+- Confirm that switching the state manually (via debug/admin if available) changes visuals correctly.
+
+Exit criteria for Phase 0:
+- All MVP blocks exist, render, and support their required state variants.
+
+---
+
+## Phase 1 — Core Logic Layer (No Game Code)
+
+**Goal:** Implement and validate all signal, frequency, and constraint logic without referencing Hytale APIs.
+
+### 1.1 Core Packages
+
+Create the following packages:
+
+- `raven.crystalcircuitry.signal`
+- `raven.crystalcircuitry.frequency`
+- `raven.crystalcircuitry.link`
+- `raven.crystalcircuitry.constraints`
+
+Code in these packages must not reference:
+- world objects
+- blocks
+- players
+- UI
+- server lifecycle
+
+---
+
+### 1.2 Frequency Model
+
+Implement the frequency system:
+
+- Frequency ID (numeric or UUID-backed)
+- `ChannelType` enum:
+    - `YELLOW`
+    - `WHITE`
+- `Frequency` object containing:
+    - frequency ID
+    - channel type
+    - active/inactive state
+    - owning emitter identifier
+
+Rules enforced here:
+- Frequencies are created explicitly (never on placement)
+- Frequencies are deleted on reset
+- Yellow and White channels never overlap
+
+Unit tests required before moving on.
+
+---
+
+### 1.3 Signal State Model
+
+Implement signal state handling:
+
+- `SignalState` enum:
+    - `ON`
+    - `OFF`
+- Explicit state transitions only
+- No ticking or time-based logic
+
+Unit tests:
+- OFF → ON → OFF transitions
+- No duplicate events
+- Idle state produces no output
+
+---
+
+### 1.4 Linking & Constraint Logic
+
+Implement pure logic for:
+
+- Yellow linking (1 emitter ↔ 1 receiver)
+- White broadcast membership (1 emitter → many receivers)
+- Door Anchor constraints (maximum of 2 doors)
+- Discovery/range checks (Yellow 100 radius, White 25 radius, Door 5 radius)
+
+Constraints enforced here:
+- Maximum link counts
+- Distance checks (math-only, no world objects)
+- Safe unlinking when entities are removed
+
+Unit tests must include:
+- invalid link rejection
+- deterministic rebinding behavior
+- cleanup on removal/reset
+
+---
+
+## Phase 2 — Persistence Layer
+
+**Goal:** Ensure save/load correctness before integrating gameplay.
+
+### 2.1 Serializable Data Models
+
+Create serializable representations for:
+
+- Frequencies
+- Emitter state
+- Receiver bindings
+- Door Anchor links
+
+Rules:
+- No direct references to world objects
+- Use IDs only (coordinates, block IDs, UUIDs)
+
+---
+
+### 2.2 Persistence Tests
+
+Write automated tests for:
+
+- serialize → deserialize round trips
+- missing or partially corrupted data
+- orphaned references
+
+Exit criteria:
+- Corrupted data never crashes the plugin
+- Invalid references are discarded safely
+
+---
+
+## Phase 3 — World Integration Layer
+
+**Goal:** Wire core logic into real blocks, UI, and blockstate changes.
+
+### 3.1 Block Registration & Placement
+
+Ensure each asset-defined block is registered/usable in-world via the plugin.
+
+---
+
+### 3.2 Blockstate Wiring (Visual + Logic Bridge)
+
+Implement the bridge between logic and visuals:
+- When logic state changes, update the corresponding block state so visuals change.
+
+Examples:
+- Switch toggled → set `cc_green_switch` state `off/on`
+- Lamp receives signal → set `cc_lamp` state `off/on`
+- Receiver linked/unlinked → update `linked_*` states
+
+Rule:
+- Block state updates must be event-driven.
+- No constant polling to “keep visuals correct.”
+
+---
+
+### 3.3 UI Wiring
+
+Implement UI screens for:
+
+- Yellow Emitters
+- Yellow Receivers
+- White Emitters
+- White Receivers
+- Door Anchors
+
+UI rules:
+- No automatic frequency generation
+- Buttons enabled/disabled based on state
+- Receivers only show valid, in-range frequencies
+- Empty-state message when no frequencies are available
+
+UI must not:
+- bypass constraints
+- contain business logic
+
+---
+
+### 3.4 In-World Event Flow Validation
+
+Validate in-game behavior:
+
+- Green switch emits exactly one event per toggle
+- Emitters generate/reset frequencies only via UI
+- Receivers display only in-range, existing frequencies
+- Lamps and doors update immediately on signal change
+- White receivers obey “any-on / all-off” rule for their tuned frequency network
+
+No background scanning or ticking systems.
+
+---
+
+## Phase 4 — Test Closure
+
+**Goal:** Prove MVP correctness.
+
+### 4.1 Automated Tests
+
+All automated tests must pass:
+
+- signal state tests
+- pairing tests
+- broadcast tests
+- constraint tests
+- persistence tests
+
+Run: `./gradlew test`
+
+---
+
+### 4.2 Manual Test Pass
+
+Execute all scenarios defined in `test-plan.md`:
+
+- fresh world
+- after server restart
+- under moderate load
+
+Fix any:
+- desynchronization
+- missed updates
+- UI inconsistencies
+- incorrect block state visuals
+
+---
+
+## Phase 5 — MVP Lock & Cleanup
+
+**Goal:** Freeze scope and prepare for submission.
+
+### 5.1 Cleanup Tasks
+
+- Remove debug logging
+- Verify no ticking systems exist
+- Confirm memory cleanup on reset/unlink
+- Validate unused frequencies are deleted
+- Verify block state updates do not spam logs or events
+
+---
+
+### 5.2 MVP Lock Rules
+
+Once MVP is locked:
+
+- No new block types
+- No new logic features
+- No UX expansion
+
+Future features (post-MVP):
+- Crystal Wrench / configuration copy tools
+- Timers and logic gates
+- Advanced movers or door systems
+
+---
+
+## Completion Criteria
+
+Implementation is complete when:
+
+- All blocks exist and render with correct state variants
+- All unit tests pass
+- All manual tests pass
+- State persists after restart
+- Server performance is stable
+- Plugin behavior matches all design documents
+
+At this point, Crystal Circuitry MVP is **feature-complete and submission-ready**.
+
+---
+
+## Final Guidance
+
+When unsure during implementation, consult documents in this order:
+
+1. `block-spec.md`
+2. `linking-ux.md`
+3. `test-plan.md`
+4. `implementation-order.md`
+
+If code conflicts with documentation, **fix the code** unless you intentionally revise the design.

--- a/docs/linking-ux.md
+++ b/docs/linking-ux.md
@@ -1,0 +1,177 @@
+# Crystal Circuitry — Linking & UX Rules (MVP)
+
+Namespace: `raven`  
+ID Prefix: `cc_`  
+Project: Crystal Circuitry  
+Applies To: MVP only
+
+This document defines how players link and configure Crystal Circuitry blocks using UI-first interactions.
+The intent is to prevent invalid actions through interface constraints rather than relying on error sounds, particles, or trial-and-error.
+
+
+---
+
+## 1. Interaction Standard
+
+### 1.1 Opening Configuration UI
+- Press F while targeting a compatible Crystal Circuitry block to open its configuration UI.
+- UI is the primary and required interaction method for linking in MVP
+
+### 1.2 UI Feedback Philosophy
+- UI must clearly show:
+  - current state (on/off, linked/unlinked) 
+  - current frequency (or none)
+-  Minimal non-UI feedback is used in MVP.
+- Invalid actions should be prevented outright by the UI wherever possible.
+
+---
+
+## 2. Frequency System (Shared Rules)
+
+### 2.1 Channel Types
+Frequencies are separated by channel type to prevent overlap:
+- `YELLOW` channel type (targeted link system)
+- `WHITE` channel type (aura/broadcast system)
+
+UI may display these as:
+- `Y-<number>` for Yellow
+- `W-<number>` for White
+
+Important Notes:
+- Internally, channel type is stored as a distinct field (not a suffix requirement).
+- Frequencies are never generated automatically. Emitters start unassigned and require explicit player action to create a frequency.
+
+
+### 2.2 Visibility Rules (Receivers)
+Receivers must only display:
+- frequencies that exist
+- frequencies within receiver discovery range (see sections 3 and 4)
+- frequencies that are enabled/active as valid sources
+
+Receivers must never display:
+- disabled frequencies
+- stale/deleted frequencies
+- options to create frequencies
+
+### 2.3 Empty State
+If no valid frequencies exist within range, the receiver UI shows:
+
+> No available frequencies in range.
+
+(Exact phrasing can be adjusted, but it must clearly explain why the list is empty.)
+
+### 2.4 Reset Behavior (Emitter Only)
+Resetting a frequency:
+- deletes the old frequency
+- generates a new frequency
+- causes any receivers tuned to the old frequency to become unlinked (or show missing/invalid until they retune)
+
+This is required to avoid stale connections and reduce unnecessary memory usage.
+
+---
+
+## 3. Yellow Link System (Targeted)
+
+### 3.1 Discovery Range
+Yellow receiver discovery radius:
+- **100 blocks** (spherical or block-distance radius; implementation-defined but consistent)
+
+### 3.2 Yellow Emitter UI (`cc_yellow_emitter`)
+UI displays:
+- Current frequency (or `None` if unassigned)
+- Button: **Generate Frequency** (only shown if no frequency exists)
+- Button: **Reset Frequency** (only shown if a frequency exists)
+
+Rules:
+- Emitter is the only block that can create/reset a Yellow frequency.
+- Reset deletes old frequency and generates a new one immediately.
+
+### 3.3 Yellow Receiver UI (`cc_yellow_receiver`)
+UI displays:
+- List of available Yellow frequencies within 100 blocks
+- Selection action: **Tune/Link to Frequency**
+- Current tuned frequency (or `None`)
+
+Rules:
+- Receiver forces one-to-one behavior (MVP):
+    - A receiver can be tuned to only one frequency at a time.
+- Receiver cannot generate or reset frequencies.
+- Receiver list shows only valid, existing, in-range frequencies.
+
+---
+
+## 4. White Aura System (Broadcast)
+
+### 4.1 Discovery Range
+White receiver discovery radius:
+- **25 blocks**
+
+### 4.2 White Emitter UI (`cc_white_emitter`)
+UI displays:
+- Current frequency (or `None` if unassigned)
+- Button: **Generate Frequency** (only shown if no frequency exists)
+- Button: **Reset Frequency** (only shown if a frequency exists)
+- Current state indicator: `active/inactive`
+
+Rules:
+- Emitter is the only block that can create/reset a White frequency.
+- Reset deletes old frequency and generates a new one immediately.
+
+### 4.3 White Receiver UI (`cc_white_receiver`)
+UI displays:
+- List of available White frequencies within 25 blocks
+- Selection action: **Tune/Link to Frequency**
+- Current tuned frequency (or `None`)
+
+Rules:
+- Receivers tuned to the same White frequency respond together (broadcast behavior).
+- Receiver list shows only valid, existing, in-range frequencies.
+- If multiple White emitters exist on different frequencies, receiver choice determines which aura network it belongs to.
+
+---
+
+## 5. Door Anchor Linking
+
+### 5.1 Door Anchor UI (`cc_door_anchor`)
+UI displays:
+- List of door blocks within range (≤ 5 blocks by default)
+- Selection controls to link up to **two** doors
+- Current linked doors (0–2)
+- Indicator showing whether the anchor is currently `on/off` (signal state)
+
+Rules:
+- Door Anchor can link to a maximum of 2 doors.
+- Door Anchor can only affect linked doors.
+- Door Anchor stores signal state only (not door state).
+- If a linked door is removed or becomes invalid, it must be removed from the anchor’s linked list automatically.
+
+### 5.2 Door Eligibility
+For MVP, eligible doors are:
+- standard door blocks that support open/close state
+
+(Exact door type detection depends on implementation, but the UX contract is: only doors that can be opened/closed are listed.)
+
+---
+
+## 6. Invalid Action Prevention (MVP)
+
+The UI should prevent invalid actions by design:
+- Receivers cannot create frequencies
+- Receivers cannot see deleted/disabled frequencies
+- Door anchor cannot link more than 2 doors
+- Door anchor cannot link doors outside range
+- Emitters can only reset their own frequency
+
+If an invalid state occurs (e.g., a door is removed), the system resolves it automatically by unlinking and updating the UI.
+
+---
+
+## MVP Completion Criteria for Linking UX
+
+Linking UX is considered complete when:
+- Players can reliably create frequencies via emitters
+- Receivers can reliably choose only available in-range frequencies
+- White and Yellow frequency spaces never overlap
+- Door anchor can link up to 2 doors and control them from a signal
+- UI prevents invalid actions without requiring particle/sound debugging
+- Future tooling (e.g., configuration-copy tools) may extend this system post-MVP.

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1,0 +1,278 @@
+# Crystal Circuitry — Test Plan (MVP)
+
+Namespace: `raven`  
+ID Prefix: `cc_`  
+Project: Crystal Circuitry  
+Applies To: MVP only
+
+This document defines **automated** and **manual** tests required to validate the Crystal Circuitry MVP.
+
+Automated tests verify logic, constraints, and persistence.  
+Manual tests verify in-world behavior, visuals, and performance.
+
+---
+
+## Testing Principles
+
+- Core logic **must** be covered by automated tests.
+- In-world behavior **must** be validated manually.
+- Automated tests must be:
+    - deterministic
+    - fast
+    - runnable headlessly
+- Manual tests must be repeatable in a fresh world.
+- No test may rely on per-tick polling.
+
+---
+
+## 1. Automated Test Suite (Required)
+
+Automated tests live under:
+
+`src/test/java/raven/crystalcircuitry/`
+
+They are executed via:
+
+`./gradlew test`
+
+These tests do **not**:
+- start a server
+- load assets
+- require a world
+
+They validate pure logic only.
+
+---
+
+### 1.1 Signal State Tests
+
+**Purpose:**  
+Validate signal state transitions without world context.
+
+**Covered Logic:**
+- Green switch emits correct signal state
+- Signal state changes only on explicit toggle
+- Idle state emits no events
+
+**Assertions:**
+- OFF → ON → OFF transitions behave correctly
+- No duplicate events are emitted
+- No state mutation without input
+
+---
+
+### 1.2 Yellow Crystal Pairing Tests
+
+**Purpose:**  
+Verify strict one-to-one pairing behavior.
+
+**Covered Logic:**
+- Emitter binds to only one receiver
+- Receiver binds to only one emitter
+- Rebinding behavior is deterministic
+
+**Assertions:**
+- Invalid pairings are rejected or replaced safely
+- No orphaned links remain
+- Pairing state serializes correctly
+
+---
+
+### 1.3 White Crystal Broadcast Logic Tests
+
+**Purpose:**  
+Validate broadcast resolution rules.
+
+**Covered Logic:**
+- Receiver activates if **any** bound emitter is active
+- Receiver deactivates only if **all** emitters are inactive
+
+**Assertions:**
+- Activation order does not matter
+- No race conditions occur
+- No lingering active state after deactivation
+
+---
+
+### 1.4 Door Anchor Constraint Tests
+
+**Purpose:**  
+Validate door anchor rules without interacting with real door blocks.
+
+**Covered Logic:**
+- Maximum of two linked doors
+- Distance constraint logic (≤ 5 blocks)
+- Safe unlinking behavior
+
+**Assertions:**
+- A third door cannot be linked
+- Invalid or removed doors are unlinked safely
+- Anchor state mirrors signal state only (not door state)
+
+---
+
+### 1.5 Persistence Tests
+
+**Purpose:**  
+Ensure save/load safety for all Crystal Circuitry data.
+
+**Covered Logic:**
+- Serialization of:
+    - Yellow emitter/receiver pairings
+    - White receiver registrations
+    - Door anchor links
+- Deserialization restores only valid state
+
+**Assertions:**
+- State survives reload
+- Invalid references are discarded safely
+- Corrupted data does not crash the plugin
+
+---
+
+## 2. Manual Integration Tests (In-World)
+
+Manual tests validate engine integration and player experience.
+
+---
+
+### 2.1 Environment Setup
+
+**Steps:**
+1. Delete the worlds folder
+2. Start the dev server
+3. Join a fresh world
+
+**Expected:**
+- Server boots cleanly
+- Plugin `raven:CrystalCircuitry` loads
+- No Crystal Circuitry errors appear in logs
+
+---
+
+### 2.2 Green Crystal Switch
+
+**Steps:**
+1. Place a Green Crystal Switch
+2. Toggle ON and OFF
+3. Toggle rapidly several times
+
+**Expected:**
+- Immediate state change
+- No visual desync
+- No idle signal emission
+
+---
+
+### 2.3 Yellow Crystal Circuit
+
+**Blocks:**
+- `cc_green_switch`
+- `cc_yellow_emitter`
+- `cc_yellow_receiver`
+- `cc_lamp`
+
+**Steps:**
+1. Pair Yellow Emitter to Yellow Receiver
+2. Attach a Crystal Lamp
+3. Toggle the Green Crystal Switch
+
+**Expected:**
+- Lamp mirrors switch state
+- Only paired receiver responds
+- Unlinked receivers remain inactive
+
+---
+
+### 2.4 White Crystal Broadcast
+
+**Blocks:**
+- `cc_white_emitter`
+- Two or more `cc_white_receiver`
+- `cc_lamp`
+
+**Steps:**
+1. Place a White Crystal Emitter
+2. Place multiple White Crystal Receivers in range
+3. Attach lamps
+4. Toggle emitter ON and OFF
+
+**Expected:**
+- All receivers activate together
+- No delay or flicker
+
+---
+
+### 2.5 Door Anchor
+
+**Blocks:**
+- `cc_door_anchor`
+- One or two standard doors
+
+**Steps:**
+1. Link one door to a Door Anchor
+2. Toggle signal ON and OFF
+3. Link a second door
+4. Toggle again
+
+**Expected:**
+- Doors open and close together
+- No state desynchronization
+- Anchor does not store door state
+
+---
+
+## 3. Persistence Tests (Manual)
+
+### 3.1 Restart Validation
+
+**Steps:**
+1. Build a circuit (switch → yellow → lamp, plus door anchor bindings)
+2. Shut down the server
+3. Restart the server
+4. Re-test toggles
+
+**Expected:**
+- Links are preserved
+- Devices still respond correctly
+- No orphaned bindings
+
+---
+
+## 4. Performance Tests (Manual)
+
+### 4.1 Moderate Load
+
+**Steps:**
+1. Place ~30 Crystal Lamps
+2. Place ~10 Green Crystal Switches
+3. Mix Yellow and White circuits
+4. Toggle repeatedly
+
+**Expected:**
+- No noticeable lag
+- No exponential signal propagation
+- No log spam
+
+---
+
+## 5. MVP Guardrails (Non-Tests)
+
+The following behaviors are out of scope and must not be implemented in MVP:
+
+- Timers, delays, or inverters
+- Tick-based polling
+- Animated block movement
+- Inventory interaction or item transport
+- Complex movers or physics systems
+
+---
+
+## MVP Completion Criteria
+
+The MVP is considered complete when:
+- `./gradlew test` passes consistently
+- All manual tests pass in a fresh world
+- State persists after restart
+- No Crystal Circuitry errors appear in logs
+- Server performance remains stable


### PR DESCRIPTION
Creating main lifecycle docs for Crystal Circuitry development;
`block-spec.md`
`dev-plan.md`
`implementation-order.md`
`linking-ux.md`
`test-plan.md`

These will dictate development cycle and act as authority on scope.